### PR TITLE
Do not require php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,6 @@
     "OSL-3.0",
     "AFL-3.0"
   ],
-  "require": {
-    "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0"
-  },
   "autoload": {
     "files": [ "registration.php" ],
     "psr-4": {


### PR DESCRIPTION
Magento modules should always support the required php versions of magento and let magento handle the requirement of php